### PR TITLE
Add license property to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "dailymotion/sdk",
+    "license": "MIT",
     "type": "library",
     "description": "Dailymotion PHP SDK",
     "keywords": ["dailymotion","sdk","api"],


### PR DESCRIPTION
The license information is mandatory. I've set "MIT", I don't know what the the current status of this one. Let me know :)
