### PR TITLE
Change how scope is defined in authorization URL

### DIFF
--- a/Dailymotion.php
+++ b/Dailymotion.php
@@ -259,7 +259,7 @@ class Dailymotion
                 'response_type' => 'code',
                 'client_id'     => $this->grantInfo['key'],
                 'redirect_uri'  => $this->grantInfo['redirect_uri'],
-                'scope'         => $this->grantInfo['scope'],
+                'scope'         => implode(' ', $this->grantInfo['scope']),
                 'display'       => $display,
             ),
             null,


### PR DESCRIPTION
if scope is defined as an array in authorization URL, it doesn't work. Scope is always userinfo and it's not possible to post new videos
