### PR TITLE
uploadFile throws an exception if the API returned an error

### DIFF
--- a/Dailymotion.php
+++ b/Dailymotion.php
@@ -328,7 +328,7 @@ class Dailymotion
         $this->timeout = $timeout;
 
         if (isset($result['error'])) {
-            throw new DailymotionApiException($result['error']);
+            throw new DailymotionApiException($result['error']['message'], $result['error']['code']);
         }
 
         return $result['url'];


### PR DESCRIPTION
I was having some trouble figuring out why I couldn't upload a temp file (without any extension) because uploadFile didn't throw any exception, just returned nothing and triggered a notice because $result['url'] was undefined.
This quick fix allows it to throw an exception, which will hopefully save some time for the next person that encounters this problem.
